### PR TITLE
remove reference to non-existent maven modules gna/comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ The modules provided by this project are:
 
  - __name-parser__: The main GBIF Name Parser implementing the API natively
  - __name-parser-api__: The minimal API to represent parsed names.
- - __name-parser-comparison__: Some comparisons to showcase different features and benchmarks of the different parsers
- - __name-parser-gna__: The [Global Names Architecture name parser](https://github.com/GlobalNamesArchitecture/gnparser) implementing the above name-parser API as an alternative implementation written in Scala
  - __name-parser-antlr__: A highly experimental parser using an ANTLR grammar for parsing.
  - __name-parser-v1__: The GBIF Name Parser wrapped to implement the [GBIF API](https://github.com/gbif/gbif-api/blob/master/src/main/java/org/gbif/api/service/checklistbank/NameParser.java)
 


### PR DESCRIPTION
hey y'all - 
I noticed some reference to non-existing maven modules (e.g., global names, comparison) in your readme. 